### PR TITLE
Feature fix unhandled

### DIFF
--- a/api/models/ItemOwners.js
+++ b/api/models/ItemOwners.js
@@ -13,11 +13,6 @@ module.exports = class ItemOwners extends Model {
 
   static schema(app, Sequelize) {
     return {
-      id: {
-        type: Sequelize.INTEGER,
-        primaryKey: true,
-        autoIncrement: true
-      },
       owner_id: {
         type: Sequelize.INTEGER,
         unique: 'item_owner_ownable'

--- a/api/models/ItemOwners.js
+++ b/api/models/ItemOwners.js
@@ -13,6 +13,11 @@ module.exports = class ItemOwners extends Model {
 
   static schema(app, Sequelize) {
     return {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true
+      },
       owner_id: {
         type: Sequelize.INTEGER,
         unique: 'item_owner_ownable'

--- a/api/services/PermissionService.js
+++ b/api/services/PermissionService.js
@@ -58,13 +58,17 @@ module.exports = class PermissionService extends Service {
   }
 
   addRoleToUser(user, roleName) {
-    user.addRole(roleName)
-    return user.save()
+    return Promise.all([
+      user.addRole(roleName),
+      user.save()
+    ])
   }
 
   removeRoleToUser(user, roleName) {
-    user.removeRole(roleName)
-    return user.save()
+    return Promise.all([
+      user.removeRole(roleName),
+      user.save()
+    ])
   }
 
   setOwning(model, models) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "joi": "^10.1.0",
     "lodash": "^4.17.3",
-    "trailpack": "^2.1.0",
+    "trailpack": "2.1.2",
     "trails-model": "^2.0.1",
     "trails-policy": "^2.0.0",
     "trails-service": "^2.0.0"
@@ -36,17 +36,17 @@
     "express": "^4.14.0",
     "mocha": "^3.2.0",
     "passport-local": "^1.0.0",
-    "semantic-release": "^6.3.2",
+    "semantic-release": "6.3.2",
     "smokesignals": "^2.1.1",
     "snyk": "^1.22.1",
     "sqlite3": "^3.1.8",
-    "supertest": "^3.0.0",
+    "supertest": "3.0.0",
     "trailpack-express": "^2.0.0",
     "trailpack-footprints": "^2.0.0",
     "trailpack-passport": "^2.0.0",
     "trailpack-router": "^2.1.0",
     "trailpack-sequelize": "^2.0.0",
-    "trails": "^2.0.0",
+    "trails": "2.0.2",
     "trails-controller": "^2.0.0"
   },
   "scripts": {


### PR DESCRIPTION
`addRoleToUser` and `removeRoleToUser` return an unhandled reject if the provided role not exists
I return a Promise.all for keeping the retro-compatibility with the `return user.save()` past behavior but I don't get why the user is saved
For a better atomicity, the only operation performed should be the set/remove of the role